### PR TITLE
Improved error catching

### DIFF
--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -11,6 +11,8 @@
         <option value="$PROJECT_DIR$/detekt.yml" />
       </list>
     </option>
+    <option name="enableDetekt" value="true" />
+    <option name="enableForProjectResult" value="Accepted" />
     <option name="enableFormatting" value="true" />
   </component>
   <component name="DetektProjectConfiguration">

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ of Ashampoo Photos, which, in turn, is driven by user community feedback.
 ## Installation
 
 ```
-implementation("com.ashampoo:kim:0.5.2")
+implementation("com.ashampoo:kim:0.5.3")
 ```
 
 ## Sample usages
 
 ### Read metadata
 
-`Kim.readMetadata()` takes `kotlin.ByteArray` & `io.ktor.utils.io.core.Input`
+`Kim.readMetadata()` takes `kotlin.ByteArray` & `io.ktor.utils.io.core.ByteReadPacket`
 on all platforms and depending on the platform also `java.io.File`,
 `java.io.InputStream`, `NSData` and string paths.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
     id("signing")
     id("io.gitlab.arturbosch.detekt") version "1.23.1"
-    id("org.sonarqube") version "4.3.1.3277"
+    id("org.sonarqube") version "4.4.1.3373"
     id("org.jetbrains.kotlinx.kover") version "0.6.1"
     id("com.asarkar.gradle.build-time-tracker") version "4.3.0"
     id("me.qoomon.git-versioning") version "6.4.2"

--- a/src/commonMain/kotlin/com/ashampoo/kim/Kim.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/Kim.kt
@@ -40,7 +40,7 @@ import com.ashampoo.kim.input.KtorInputByteReader
 import com.ashampoo.kim.input.PrePendingByteReader
 import com.ashampoo.kim.model.ImageFormat
 import com.ashampoo.kim.model.MetadataUpdate
-import io.ktor.utils.io.core.Input
+import io.ktor.utils.io.core.ByteReadPacket
 import io.ktor.utils.io.core.use
 
 object Kim {
@@ -54,8 +54,8 @@ object Kim {
 
     @kotlin.jvm.JvmStatic
     @Throws(ImageReadException::class)
-    fun readMetadata(input: Input): ImageMetadata? =
-        readMetadata(KtorInputByteReader(input), input.remaining)
+    fun readMetadata(byteReadPacket: ByteReadPacket): ImageMetadata? =
+        readMetadata(KtorInputByteReader(byteReadPacket), byteReadPacket.remaining)
 
     @kotlin.jvm.JvmStatic
     @Throws(ImageReadException::class)

--- a/src/commonMain/kotlin/com/ashampoo/kim/Kim.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/Kim.kt
@@ -115,6 +115,7 @@ object Kim {
         }
     }
 
+    @kotlin.jvm.JvmStatic
     @Throws(ImageReadException::class)
     fun extractPreviewImage(
         byteReader: ByteReader,
@@ -162,6 +163,7 @@ object Kim {
      * **Note**: We don't have an good API for single-shot write all fields right now.
      * So this is inefficent at this time. This method is experimental and will likely change.
      */
+    @kotlin.jvm.JvmStatic
     @Throws(ImageWriteException::class)
     fun update(
         bytes: ByteArray,

--- a/src/commonMain/kotlin/com/ashampoo/kim/common/Exceptions.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/common/Exceptions.kt
@@ -24,5 +24,32 @@ class ImageReadException(message: String? = null, cause: Throwable? = null) :
 open class ImageWriteException(message: String? = null, cause: Throwable? = null) :
     ImageException(message, cause)
 
-class ExifOverflowException(message: String) :
-    ImageWriteException(message, null)
+inline fun <R> tryWithImageReadException(block: () -> R): R {
+    return try {
+        block()
+    } catch (ex: ImageReadException) {
+        /* Don't wrap another ImageReadException. */
+        throw ex
+    } catch (ex: Throwable) {
+        /*
+         * We need to ensure that everything that can fail is an ImageReadException,
+         * because on Kotlin/Native this is the expected exception type.
+         */
+        throw ImageReadException("Failed to read image.", ex)
+    }
+}
+
+inline fun <R> tryWithImageWriteException(block: () -> R): R {
+    return try {
+        block()
+    } catch (ex: ImageWriteException) {
+        /* Don't wrap another ImageWriteException. */
+        throw ex
+    } catch (ex: Throwable) {
+        /*
+         * We need to ensure that everything that can fail is an ImageWriteException,
+         * because on Kotlin/Native this is the expected exception type.
+         */
+        throw ImageWriteException("Failed to write image.", ex)
+    }
+}

--- a/src/commonMain/kotlin/com/ashampoo/kim/common/Exceptions.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/common/Exceptions.kt
@@ -24,32 +24,30 @@ class ImageReadException(message: String? = null, cause: Throwable? = null) :
 open class ImageWriteException(message: String? = null, cause: Throwable? = null) :
     ImageException(message, cause)
 
-inline fun <R> tryWithImageReadException(block: () -> R): R {
-    return try {
+/**
+ * We need to ensure that every Exception that can occur is wrapped
+ * into an ImageReadException, because on Kotlin/Native this is the expected exception type.
+ */
+inline fun <R> tryWithImageReadException(block: () -> R): R =
+    try {
         block()
     } catch (ex: ImageReadException) {
         /* Don't wrap another ImageReadException. */
         throw ex
     } catch (ex: Throwable) {
-        /*
-         * We need to ensure that everything that can fail is an ImageReadException,
-         * because on Kotlin/Native this is the expected exception type.
-         */
         throw ImageReadException("Failed to read image.", ex)
     }
-}
 
-inline fun <R> tryWithImageWriteException(block: () -> R): R {
-    return try {
+/**
+ * We need to ensure that everything is wrapped into an ImageWriteException,
+ * because on Kotlin/Native this is the expected exception type.
+ */
+inline fun <R> tryWithImageWriteException(block: () -> R): R =
+    try {
         block()
     } catch (ex: ImageWriteException) {
         /* Don't wrap another ImageWriteException. */
         throw ex
     } catch (ex: Throwable) {
-        /*
-         * We need to ensure that everything that can fail is an ImageWriteException,
-         * because on Kotlin/Native this is the expected exception type.
-         */
         throw ImageWriteException("Failed to write image.", ex)
     }
-}

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/ImageParser.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/ImageParser.kt
@@ -16,6 +16,7 @@
  */
 package com.ashampoo.kim.format
 
+import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.format.jpeg.JpegImageParser
 import com.ashampoo.kim.format.png.PngImageParser
 import com.ashampoo.kim.format.raf.RafImageParser
@@ -25,6 +26,7 @@ import com.ashampoo.kim.model.ImageFormat
 
 fun interface ImageParser {
 
+    @Throws(ImageReadException::class)
     fun parseMetadata(byteReader: ByteReader, length: Long): ImageMetadata
 
     companion object {

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/MetadataExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/MetadataExtractor.kt
@@ -15,10 +15,12 @@
  */
 package com.ashampoo.kim.format
 
+import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.input.ByteReader
 
 fun interface MetadataExtractor {
 
+    @Throws(ImageReadException::class)
     fun extractMetadataBytes(byteReader: ByteReader): ByteArray
 
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/MetadataUpdater.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/MetadataUpdater.kt
@@ -15,10 +15,12 @@
  */
 package com.ashampoo.kim.format
 
+import com.ashampoo.kim.common.ImageWriteException
 import com.ashampoo.kim.model.MetadataUpdate
 
 fun interface MetadataUpdater {
 
+    @Throws(ImageWriteException::class)
     fun update(bytes: ByteArray, updates: Set<MetadataUpdate>): ByteArray
 
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/TiffPreviewExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/TiffPreviewExtractor.kt
@@ -15,11 +15,13 @@
  */
 package com.ashampoo.kim.format
 
+import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.format.tiff.TiffContents
 import com.ashampoo.kim.input.RandomAccessByteReader
 
 fun interface TiffPreviewExtractor {
 
+    @Throws(ImageReadException::class)
     fun extractPreviewImage(
         tiffContents: TiffContents,
         randomAccessByteReader: RandomAccessByteReader

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/arw/ArwPreviewExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/arw/ArwPreviewExtractor.kt
@@ -16,6 +16,8 @@
  */
 package com.ashampoo.kim.format.arw
 
+import com.ashampoo.kim.common.ImageReadException
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.TiffPreviewExtractor
 import com.ashampoo.kim.format.tiff.TiffContents
 import com.ashampoo.kim.format.tiff.constants.TiffTag
@@ -23,10 +25,11 @@ import com.ashampoo.kim.input.RandomAccessByteReader
 
 object ArwPreviewExtractor : TiffPreviewExtractor {
 
+    @Throws(ImageReadException::class)
     override fun extractPreviewImage(
         tiffContents: TiffContents,
         randomAccessByteReader: RandomAccessByteReader
-    ): ByteArray? {
+    ): ByteArray? = tryWithImageReadException {
 
         val ifd0 = tiffContents.directories.first()
 
@@ -43,6 +46,6 @@ object ArwPreviewExtractor : TiffPreviewExtractor {
 
         val previewBytes = randomAccessByteReader.readBytes(previewLength)
 
-        return previewBytes
+        return@tryWithImageReadException previewBytes
     }
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/cr2/Cr2PreviewExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/cr2/Cr2PreviewExtractor.kt
@@ -16,6 +16,8 @@
  */
 package com.ashampoo.kim.format.cr2
 
+import com.ashampoo.kim.common.ImageReadException
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.TiffPreviewExtractor
 import com.ashampoo.kim.format.tiff.TiffContents
 import com.ashampoo.kim.format.tiff.constants.TiffTag
@@ -23,10 +25,11 @@ import com.ashampoo.kim.input.RandomAccessByteReader
 
 object Cr2PreviewExtractor : TiffPreviewExtractor {
 
+    @Throws(ImageReadException::class)
     override fun extractPreviewImage(
         tiffContents: TiffContents,
         randomAccessByteReader: RandomAccessByteReader
-    ): ByteArray? {
+    ): ByteArray? = tryWithImageReadException {
 
         val ifd0 = tiffContents.directories.first()
 
@@ -43,6 +46,6 @@ object Cr2PreviewExtractor : TiffPreviewExtractor {
 
         val previewBytes = randomAccessByteReader.readBytes(previewLength)
 
-        return previewBytes
+        return@tryWithImageReadException previewBytes
     }
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/dng/DngPreviewExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/dng/DngPreviewExtractor.kt
@@ -16,6 +16,8 @@
  */
 package com.ashampoo.kim.format.dng
 
+import com.ashampoo.kim.common.ImageReadException
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.TiffPreviewExtractor
 import com.ashampoo.kim.format.tiff.TiffContents
 import com.ashampoo.kim.format.tiff.constants.ExifTag
@@ -25,10 +27,11 @@ import com.ashampoo.kim.input.RandomAccessByteReader
 
 object DngPreviewExtractor : TiffPreviewExtractor {
 
+    @Throws(ImageReadException::class)
     override fun extractPreviewImage(
         tiffContents: TiffContents,
         randomAccessByteReader: RandomAccessByteReader
-    ): ByteArray? {
+    ): ByteArray? = tryWithImageReadException {
 
         val ifd0 = tiffContents.directories.first()
 
@@ -53,6 +56,6 @@ object DngPreviewExtractor : TiffPreviewExtractor {
 
         val previewBytes = randomAccessByteReader.readBytes(previewLength)
 
-        return previewBytes
+        return@tryWithImageReadException previewBytes
     }
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegImageParser.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegImageParser.kt
@@ -19,6 +19,7 @@ package com.ashampoo.kim.format.jpeg
 import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.common.getRemainingBytes
 import com.ashampoo.kim.common.startsWith
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.ImageMetadata
 import com.ashampoo.kim.format.ImageParser
 import com.ashampoo.kim.format.jpeg.iptc.IptcMetadata
@@ -42,26 +43,27 @@ object JpegImageParser : ImageParser {
     private fun keepMarker(marker: Int, markers: List<Int>?): Boolean =
         markers?.contains(marker) ?: false
 
-    override fun parseMetadata(byteReader: ByteReader, length: Long): ImageMetadata {
+    override fun parseMetadata(byteReader: ByteReader, length: Long): ImageMetadata =
+        tryWithImageReadException {
 
-        val segments = readSegments(
-            byteReader,
-            JpegConstants.SOFN_MARKERS +
-                listOf(JpegConstants.JPEG_APP1_MARKER, JpegConstants.JPEG_APP13_MARKER)
-        )
+            val segments = readSegments(
+                byteReader,
+                JpegConstants.SOFN_MARKERS +
+                    listOf(JpegConstants.JPEG_APP1_MARKER, JpegConstants.JPEG_APP13_MARKER)
+            )
 
-        val imageSize = getImageSize(segments)
+            val imageSize = getImageSize(segments)
 
-        val exifBytes = getExifBytes(segments)
+            val exifBytes = getExifBytes(segments)
 
-        val exif = if (exifBytes != null) getExif(exifBytes) else null
+            val exif = if (exifBytes != null) getExif(exifBytes) else null
 
-        val iptc = getIptc(segments)
+            val iptc = getIptc(segments)
 
-        val xmp = getXmpXml(segments)
+            val xmp = getXmpXml(segments)
 
-        return ImageMetadata(ImageFormat.JPEG, imageSize, exif, exifBytes, iptc, xmp)
-    }
+            return ImageMetadata(ImageFormat.JPEG, imageSize, exif, exifBytes, iptc, xmp)
+        }
 
     private fun readSegments(byteReader: ByteReader, markers: List<Int>): List<Segment> {
 

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegImageParser.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegImageParser.kt
@@ -56,7 +56,7 @@ object JpegImageParser : ImageParser {
 
             val exifBytes = getExifBytes(segments)
 
-            val exif = if (exifBytes != null) getExif(exifBytes) else null
+            val exif = exifBytes?.let { getExif(it) }
 
             val iptc = getIptc(segments)
 
@@ -71,14 +71,11 @@ object JpegImageParser : ImageParser {
 
         val visitor: JpegVisitor = object : JpegVisitor {
 
-            override fun beginSOS(): Boolean {
-                /* Don't read actual image data. */
-                return false
-            }
+            /* Don't read actual image data. */
+            override fun beginSOS(): Boolean = false
 
-            override fun visitSOS(marker: Int, markerBytes: ByteArray, imageData: ByteArray) {
+            override fun visitSOS(marker: Int, markerBytes: ByteArray, imageData: ByteArray) =
                 error("Should not be called.")
-            }
 
             // return false to exit traversal.
             override fun visitSegment(

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegMetadataExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegMetadataExtractor.kt
@@ -19,6 +19,7 @@ import com.ashampoo.kim.common.ByteOrder
 import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.common.toSingleNumberHexes
 import com.ashampoo.kim.common.toUInt16
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.ImageFormatMagicNumbers
 import com.ashampoo.kim.format.MetadataExtractor
 import com.ashampoo.kim.input.ByteReader
@@ -31,8 +32,11 @@ object JpegMetadataExtractor : MetadataExtractor {
 
     private const val ADDITIONAL_BYTE_COUNT_AFTER_HEADER: Int = 12
 
+    @Throws(ImageReadException::class)
     @Suppress("ComplexMethod")
-    override fun extractMetadataBytes(byteReader: ByteReader): ByteArray {
+    override fun extractMetadataBytes(
+        byteReader: ByteReader
+    ): ByteArray = tryWithImageReadException {
 
         val bytes = mutableListOf<Byte>()
 
@@ -47,7 +51,7 @@ object JpegMetadataExtractor : MetadataExtractor {
 
         readSegmentBytesIntoList(byteReader, bytes)
 
-        /**
+        /*
          * Add some more bytes after the header, so it's recognized
          * by most image viewers as a valid (but broken) file.
          */
@@ -58,7 +62,7 @@ object JpegMetadataExtractor : MetadataExtractor {
             }
         }
 
-        return bytes.toByteArray()
+        return@tryWithImageReadException bytes.toByteArray()
     }
 
     internal fun readSegmentBytesIntoList(

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegRewriter.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegRewriter.kt
@@ -105,8 +105,10 @@ object JpegRewriter : BinaryFileParser() {
 
             mergedSegments.addAll(1, newSegments)
 
-        } else
+        } else {
+
             mergedSegments.addAll(lastAppIndex + 1, newSegments)
+        }
 
         return mergedSegments
     }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegRewriter.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegRewriter.kt
@@ -17,7 +17,6 @@
 package com.ashampoo.kim.format.jpeg
 
 import com.ashampoo.kim.common.BinaryFileParser
-import com.ashampoo.kim.common.ExifOverflowException
 import com.ashampoo.kim.common.ImageWriteException
 import com.ashampoo.kim.common.getRemainingBytes
 import com.ashampoo.kim.common.toBytes
@@ -155,7 +154,7 @@ object JpegRewriter : BinaryFileParser() {
             val markerBytes = JpegConstants.JPEG_APP1_MARKER.toShort().toBytes(byteOrder)
 
             if (newBytes.size > JpegConstants.MAX_SEGMENT_SIZE)
-                throw ExifOverflowException("APP1 Segment is too long: " + newBytes.size)
+                throw ImageWriteException("APP1 Segment is too long: " + newBytes.size)
 
             val markerLength = newBytes.size + 2
             val markerLengthBytes = markerLength.toShort().toBytes(byteOrder)
@@ -192,7 +191,7 @@ object JpegRewriter : BinaryFileParser() {
                 val markerBytes = JpegConstants.JPEG_APP1_MARKER.toShort().toBytes(byteOrder)
 
                 if (newBytes.size > JpegConstants.MAX_SEGMENT_SIZE)
-                    throw ExifOverflowException("APP1 Segment is too long: " + newBytes.size)
+                    throw ImageWriteException("APP1 Segment is too long: " + newBytes.size)
 
                 val markerLength = newBytes.size + 2
                 val markerLengthBytes = markerLength.toShort().toBytes(byteOrder)

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegUpdater.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/jpeg/JpegUpdater.kt
@@ -17,6 +17,7 @@ package com.ashampoo.kim.format.jpeg
 
 import com.ashampoo.kim.Kim
 import com.ashampoo.kim.common.ImageWriteException
+import com.ashampoo.kim.common.tryWithImageWriteException
 import com.ashampoo.kim.format.MetadataUpdater
 import com.ashampoo.kim.format.jpeg.iptc.IptcMetadata
 import com.ashampoo.kim.format.jpeg.iptc.IptcRecord
@@ -33,10 +34,11 @@ import com.ashampoo.xmp.XMPMetaFactory
 
 internal object JpegUpdater : MetadataUpdater {
 
+    @Throws(ImageWriteException::class)
     override fun update(
         bytes: ByteArray,
         updates: Set<MetadataUpdate>
-    ): ByteArray {
+    ): ByteArray = tryWithImageWriteException {
 
         if (updates.isEmpty())
             return bytes
@@ -55,7 +57,7 @@ internal object JpegUpdater : MetadataUpdater {
 
         val iptcUpdatedBytes = updateIptc(exifUpdatedBytes, kimMetadata.iptc, updates)
 
-        return iptcUpdatedBytes
+        return@tryWithImageWriteException iptcUpdatedBytes
     }
 
     private fun updateXmp(inputBytes: ByteArray, xmp: String?, updates: Set<MetadataUpdate>): ByteArray {

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/nef/NefPreviewExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/nef/NefPreviewExtractor.kt
@@ -16,6 +16,8 @@
  */
 package com.ashampoo.kim.format.nef
 
+import com.ashampoo.kim.common.ImageReadException
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.TiffPreviewExtractor
 import com.ashampoo.kim.format.tiff.TiffContents
 import com.ashampoo.kim.format.tiff.constants.TiffConstants
@@ -24,10 +26,11 @@ import com.ashampoo.kim.input.RandomAccessByteReader
 
 object NefPreviewExtractor : TiffPreviewExtractor {
 
+    @Throws(ImageReadException::class)
     override fun extractPreviewImage(
         tiffContents: TiffContents,
         randomAccessByteReader: RandomAccessByteReader
-    ): ByteArray? {
+    ): ByteArray? = tryWithImageReadException {
 
         val ifd1 = tiffContents.directories.find {
             it.type == TiffConstants.TIFF_IFD1
@@ -46,6 +49,6 @@ object NefPreviewExtractor : TiffPreviewExtractor {
 
         val previewBytes = randomAccessByteReader.readBytes(previewLength)
 
-        return previewBytes
+        return@tryWithImageReadException previewBytes
     }
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngMetadataExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngMetadataExtractor.kt
@@ -17,6 +17,7 @@ package com.ashampoo.kim.format.png
 
 import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.common.toSingleNumberHexes
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.ImageFormatMagicNumbers
 import com.ashampoo.kim.format.MetadataExtractor
 import com.ashampoo.kim.input.ByteReader
@@ -50,8 +51,11 @@ object PngMetadataExtractor : MetadataExtractor {
         0xAE.toByte(), 42.toByte(), 60.toByte(), 82.toByte()
     )
 
+    @Throws(ImageReadException::class)
     @Suppress("ComplexMethod", "LoopWithTooManyJumpStatements")
-    override fun extractMetadataBytes(byteReader: ByteReader): ByteArray {
+    override fun extractMetadataBytes(
+        byteReader: ByteReader
+    ): ByteArray = tryWithImageReadException {
 
         val bytes = mutableListOf<Byte>()
 
@@ -121,7 +125,7 @@ object PngMetadataExtractor : MetadataExtractor {
         bytes.addAll(PngChunkType.IEND.bytes.toList())
         bytes.addAll(imageEndChunkCrc)
 
-        return bytes.toByteArray()
+        return@tryWithImageReadException bytes.toByteArray()
     }
 
     fun extractExifBytes(reader: ByteReader): ByteArray? {

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngUpdater.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngUpdater.kt
@@ -17,6 +17,7 @@ package com.ashampoo.kim.format.png
 
 import com.ashampoo.kim.Kim
 import com.ashampoo.kim.common.ImageWriteException
+import com.ashampoo.kim.common.tryWithImageWriteException
 import com.ashampoo.kim.format.MetadataUpdater
 import com.ashampoo.kim.format.tiff.write.TiffImageWriterLossless
 import com.ashampoo.kim.format.tiff.write.TiffImageWriterLossy
@@ -30,10 +31,11 @@ import com.ashampoo.xmp.XMPMetaFactory
 
 internal object PngUpdater : MetadataUpdater {
 
+    @Throws(ImageWriteException::class)
     override fun update(
         bytes: ByteArray,
         updates: Set<MetadataUpdate>
-    ): ByteArray {
+    ): ByteArray = tryWithImageWriteException {
 
         if (updates.isEmpty())
             return bytes
@@ -96,6 +98,6 @@ internal object PngUpdater : MetadataUpdater {
             xmp = updatedXmp
         )
 
-        return byteWriter.toByteArray()
+        return@tryWithImageWriteException byteWriter.toByteArray()
     }
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngUpdater.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngUpdater.kt
@@ -80,8 +80,9 @@ internal object PngUpdater : MetadataUpdater {
 
             exifBytesWriter.toByteArray()
 
-        } else
+        } else {
             null
+        }
 
         val byteWriter = ByteArrayByteWriter()
 

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/raf/RafMetadataExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/raf/RafMetadataExtractor.kt
@@ -15,7 +15,9 @@
  */
 package com.ashampoo.kim.format.raf
 
+import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.common.toSingleNumberHexes
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.ImageFormatMagicNumbers
 import com.ashampoo.kim.format.MetadataExtractor
 import com.ashampoo.kim.format.jpeg.JpegMetadataExtractor
@@ -28,7 +30,10 @@ object RafMetadataExtractor : MetadataExtractor {
      * The RAF file contains a JPEG with EXIF metadata.
      * We just have to find it and read the data from there it.
      */
-    override fun extractMetadataBytes(byteReader: ByteReader): ByteArray {
+    @Throws(ImageReadException::class)
+    override fun extractMetadataBytes(
+        byteReader: ByteReader
+    ): ByteArray = tryWithImageReadException {
 
         val magicNumberBytes = byteReader.readBytes(ImageFormatMagicNumbers.raf.size).toList()
 
@@ -45,11 +50,11 @@ object RafMetadataExtractor : MetadataExtractor {
             prependedBytes = ImageFormatMagicNumbers.jpeg
         )
 
-        return JpegMetadataExtractor.extractMetadataBytes(newReader)
+        return@tryWithImageReadException JpegMetadataExtractor.extractMetadataBytes(newReader)
     }
 
     @Suppress("ComplexCondition", "LoopWithTooManyJumpStatements")
-    fun skipToJpegMagicBytes(byteReader: ByteReader) {
+    internal fun skipToJpegMagicBytes(byteReader: ByteReader) {
 
         @Suppress("kotlin:S1481") // false positive
         val bytes = mutableListOf<Byte>()

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/raf/RafPreviewExtractor.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/raf/RafPreviewExtractor.kt
@@ -16,16 +16,19 @@
  */
 package com.ashampoo.kim.format.raf
 
+import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.common.toSingleNumberHexes
+import com.ashampoo.kim.common.tryWithImageReadException
 import com.ashampoo.kim.format.ImageFormatMagicNumbers
 import com.ashampoo.kim.format.jpeg.JpegMetadataExtractor
 import com.ashampoo.kim.input.ByteReader
 
 object RafPreviewExtractor {
 
+    @Throws(ImageReadException::class)
     fun extractPreviewImage(
         reader: ByteReader
-    ): ByteArray? {
+    ): ByteArray? = tryWithImageReadException {
 
         val magicNumberBytes = reader.readBytes(ImageFormatMagicNumbers.raf.size).toList()
 
@@ -60,6 +63,6 @@ object RafPreviewExtractor {
             ) break
         }
 
-        return bytes.toByteArray()
+        return@tryWithImageReadException bytes.toByteArray()
     }
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/xmp/XmpReader.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/xmp/XmpReader.kt
@@ -23,6 +23,7 @@ import com.ashampoo.kim.model.PhotoRating
 import com.ashampoo.kim.model.RegionArea
 import com.ashampoo.kim.model.TiffOrientation
 import com.ashampoo.xmp.XMPConst
+import com.ashampoo.xmp.XMPException
 import com.ashampoo.xmp.XMPMetaFactory
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -42,6 +43,7 @@ object XmpReader {
     private const val XMP_ACDSEE_KEYWORDS = "keywords"
 
     @Suppress("LoopWithTooManyJumpStatements")
+    @Throws(XMPException::class)
     fun readMetadata(xmp: String): PhotoMetadata {
 
         val xmpMeta = XMPMetaFactory.parseFromString(xmp)

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/xmp/XmpWriter.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/xmp/XmpWriter.kt
@@ -19,6 +19,7 @@ import com.ashampoo.kim.Kim.underUnitTesting
 import com.ashampoo.kim.common.GpsUtil
 import com.ashampoo.kim.model.MetadataUpdate
 import com.ashampoo.xmp.XMPConst
+import com.ashampoo.xmp.XMPException
 import com.ashampoo.xmp.XMPMeta
 import com.ashampoo.xmp.XMPMetaFactory
 import com.ashampoo.xmp.options.PropertyOptions
@@ -48,6 +49,7 @@ object XmpWriter {
     /**
      * @param writePackageWrapper Should be "true" for embedded XMP
      */
+    @Throws(XMPException::class)
     @Suppress("LoopWithTooManyJumpStatements")
     fun updateXmp(
         xmpMeta: XMPMeta,

--- a/src/commonMain/kotlin/com/ashampoo/kim/input/KtorInputByteReader.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/input/KtorInputByteReader.kt
@@ -15,7 +15,7 @@
  */
 package com.ashampoo.kim.input
 
-import io.ktor.utils.io.core.Input
+import io.ktor.utils.io.core.ByteReadPacket
 import io.ktor.utils.io.core.readBytes
 
 /**
@@ -24,15 +24,15 @@ import io.ktor.utils.io.core.readBytes
  * of files hosted on a cloud service, which is a common use case.
  */
 class KtorInputByteReader(
-    private val input: Input
+    private val byteReadPacket: ByteReadPacket
 ) : ByteReader {
 
     override fun readByte(): Byte? =
-        if (input.endOfInput) null else input.readByte()
+        if (byteReadPacket.endOfInput) null else byteReadPacket.readByte()
 
     override fun readBytes(count: Int): ByteArray =
-        input.readBytes(minOf(count, input.remaining.toInt()))
+        byteReadPacket.readBytes(minOf(count, byteReadPacket.remaining.toInt()))
 
     override fun close() =
-        input.close()
+        byteReadPacket.close()
 }

--- a/src/commonMain/kotlin/com/ashampoo/kim/model/ImageFormat.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/model/ImageFormat.kt
@@ -15,7 +15,6 @@
  */
 package com.ashampoo.kim.model
 
-import com.ashampoo.kim.common.ImageReadException
 import com.ashampoo.kim.common.startsWith
 import com.ashampoo.kim.common.startsWithNullable
 import com.ashampoo.kim.common.toSingleNumberHexes
@@ -132,16 +131,21 @@ enum class ImageFormat(
         /**
          * Detects JPEG, GIF, PNG, TIFF & WEBP files based on the header bytes.
          *
+         * If the byte array is less than REQUIRED_HEADER_BYTE_COUNT_FOR_DETECTION
+         * (for example empty) than the detection returns null.
+         *
          * Note: Can NOT detect HEIC!
          */
         @JvmStatic
         fun detect(bytes: ByteArray): ImageFormat? {
 
-            if (bytes.isEmpty())
-                return null
-
+            /*
+             * If empty or not enough bytes we can't detect the format and will return NULL.
+             * We don't want to throw an Exception, because we can't change the fact that
+             * a file is too short to be an image and also we don't want Kotlin/Native to crash.
+             */
             if (bytes.size < REQUIRED_HEADER_BYTE_COUNT_FOR_DETECTION)
-                throw ImageReadException("Only got ${bytes.size} for detection of format.")
+                return null
 
             /*
              * We want to exit this detection early, so we order the

--- a/src/commonMain/kotlin/com/ashampoo/kim/model/PhotoMetadata.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/model/PhotoMetadata.kt
@@ -57,10 +57,9 @@ data class PhotoMetadata(
 
 ) {
 
-    val takenDateLocalDateTime: LocalDateTime? = if (takenDate != null)
+    val takenDateLocalDateTime: LocalDateTime? = takenDate?.let {
         Instant.fromEpochMilliseconds(takenDate).toLocalDateTime(TimeZone.currentSystemDefault())
-    else
-        null
+    }
 
     val megaPixelCount: Int = if (widthPx == null || heightPx == null)
         0
@@ -70,10 +69,8 @@ data class PhotoMetadata(
     val locationDisplay: String? =
         if (location != null)
             location.displayString
-        else if (gpsCoordinates != null)
-            gpsCoordinates.displayString
         else
-            null
+            gpsCoordinates?.let { gpsCoordinates.displayString }
 
     val cameraName: String? =
         PhotoValueFormatter.createCameraOrLensName(cameraMake, cameraModel)
@@ -88,10 +85,6 @@ data class PhotoMetadata(
         cameraName = cameraName,
         lensName = lensName
     )
-
-    /* For SwiftUI ForEach */
-    @Suppress("unused")
-    val keywordsAsList: List<String> = keywords.toList()
 
     @Suppress("DataClassContainsFunctions")
     fun isEmpty(): Boolean = this == emptyPhotoMetadata

--- a/src/commonTest/kotlin/com/ashampoo/kim/ImageMetadataTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/ImageMetadataTest.kt
@@ -16,7 +16,9 @@
 package com.ashampoo.kim
 
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.Test
 import kotlin.test.fail
@@ -48,7 +50,10 @@ class ImageMetadataTest {
 
             if (!equals) {
 
-                Path("build/photo_$index.txt").sink().use { it.write(actualToString) }
+                SystemFileSystem
+                    .sink(Path("build/photo_$index.txt"))
+                    .buffered()
+                    .use { it.write(actualToString) }
 
                 fail("photo_$index.txt is different.")
             }

--- a/src/commonTest/kotlin/com/ashampoo/kim/PreviewImageExtractionTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/PreviewImageExtractionTest.kt
@@ -17,7 +17,9 @@ package com.ashampoo.kim
 
 import com.ashampoo.kim.input.ByteArrayByteReader
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -65,9 +67,10 @@ class PreviewImageExtractionTest {
 
             if (!equals) {
 
-                Path("build/photo_${index}_preview.jpg").sink().use {
-                    it.write(previewImageBytes)
-                }
+                SystemFileSystem
+                    .sink(Path("build/photo_${index}_preview.jpg"))
+                    .buffered()
+                    .use { it.write(previewImageBytes) }
 
                 fail("Photo $index has not the expected bytes!")
             }

--- a/src/commonTest/kotlin/com/ashampoo/kim/XmpExtractionTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/XmpExtractionTest.kt
@@ -16,7 +16,9 @@
 package com.ashampoo.kim
 
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -71,7 +73,10 @@ class XmpExtractionTest {
 
             if (!equals) {
 
-                Path("build/photo_$index.xmp").sink().use { it.write(actualXmpBytes) }
+                SystemFileSystem
+                    .sink(Path("build/photo_$index.xmp"))
+                    .buffered()
+                    .use { it.write(actualXmpBytes) }
 
                 fail("Photo $index has not the expected bytes!")
             }

--- a/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/ExifThumbnailExtractionTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/ExifThumbnailExtractionTest.kt
@@ -17,7 +17,9 @@ package com.ashampoo.kim.format.jpeg
 
 import com.ashampoo.kim.Kim
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.Test
 import kotlin.test.assertNotNull
@@ -56,7 +58,10 @@ class ExifThumbnailExtractionTest {
 
             if (!equals) {
 
-                Path("build/photo_${index}_exifthumb.jpg").sink().use { it.write(actualThumbnailBytes) }
+                SystemFileSystem
+                    .sink(Path("build/photo_${index}_exifthumb.jpg"))
+                    .buffered()
+                    .use { it.write(actualThumbnailBytes) }
 
                 fail("Photo $index has not the expected bytes!")
             }

--- a/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/JpegMetadataExtractorTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/JpegMetadataExtractorTest.kt
@@ -18,7 +18,9 @@ package com.ashampoo.kim.format.jpeg
 import com.ashampoo.kim.Kim
 import com.ashampoo.kim.input.ByteArrayByteReader
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.Test
 import kotlin.test.fail
@@ -47,7 +49,10 @@ class JpegMetadataExtractorTest {
 
             if (!equals) {
 
-                Path("build/photo_${index}_header.jpg").sink().use { it.write(actualMetadataBytes) }
+                SystemFileSystem
+                    .sink(Path("build/photo_${index}_header.jpg"))
+                    .buffered()
+                    .use { it.write(actualMetadataBytes) }
 
                 fail("Photo $index has not the expected bytes!")
             }

--- a/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/JpegRewriterTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/JpegRewriterTest.kt
@@ -28,7 +28,9 @@ import com.ashampoo.kim.input.ByteArrayByteReader
 import com.ashampoo.kim.model.GpsCoordinates
 import com.ashampoo.kim.output.ByteArrayByteWriter
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -151,7 +153,10 @@ class JpegRewriterTest {
 
             if (!equals) {
 
-                Path("build/photo_${index}_modified.jpg").sink().use { it.write(actualMetadataBytes) }
+                SystemFileSystem
+                    .sink(Path("build/photo_${index}_modified.jpg"))
+                    .buffered()
+                    .use { it.write(actualMetadataBytes) }
 
                 fail("Photo $index has not the expected bytes!")
             }

--- a/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/JpegUpdaterTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/format/jpeg/JpegUpdaterTest.kt
@@ -21,7 +21,9 @@ import com.ashampoo.kim.model.MetadataUpdate
 import com.ashampoo.kim.model.PhotoRating
 import com.ashampoo.kim.model.TiffOrientation
 import com.goncalossilva.resources.Resource
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -138,7 +140,10 @@ class JpegUpdaterTest {
 
         if (!resource.exists()) {
 
-            Path("build/$fileName").sink().use { it.write(actualBytes) }
+            SystemFileSystem
+                .sink(Path("build/$fileName"))
+                .buffered()
+                .use { it.write(actualBytes) }
 
             fail("Reference image $fileName does not exist.")
         }

--- a/src/commonTest/kotlin/com/ashampoo/kim/format/png/PngUpdaterTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/format/png/PngUpdaterTest.kt
@@ -21,7 +21,9 @@ import com.ashampoo.kim.model.MetadataUpdate
 import com.ashampoo.kim.model.PhotoRating
 import com.ashampoo.kim.model.TiffOrientation
 import com.goncalossilva.resources.Resource
+import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -138,7 +140,10 @@ class PngUpdaterTest {
 
         if (!resource.exists()) {
 
-            Path("build/$fileName").sink().use { it.write(actualBytes) }
+            SystemFileSystem
+                .sink(Path("build/$fileName"))
+                .buffered()
+                .use { it.write(actualBytes) }
 
             fail("Reference image $fileName does not exist.")
         }
@@ -149,7 +154,10 @@ class PngUpdaterTest {
 
         if (!equals) {
 
-            Path("build/$fileName").sink().use { it.write(actualBytes) }
+            SystemFileSystem
+                .sink(Path("build/$fileName"))
+                .buffered()
+                .use { it.write(actualBytes) }
 
             fail("Photo $fileName has not the expected bytes!")
         }

--- a/src/commonTest/kotlin/com/ashampoo/kim/format/png/PngWriterTest.kt
+++ b/src/commonTest/kotlin/com/ashampoo/kim/format/png/PngWriterTest.kt
@@ -28,7 +28,10 @@ import com.ashampoo.kim.format.tiff.write.TiffImageWriterLossy
 import com.ashampoo.kim.format.tiff.write.TiffOutputSet
 import com.ashampoo.kim.output.ByteArrayByteWriter
 import com.ashampoo.kim.testdata.KimTestData
+import kotlinx.io.buffered
+import kotlinx.io.files.FileSystem
 import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.files.sink
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -145,7 +148,10 @@ class PngWriterTest {
 
             if (!equals) {
 
-                Path("build/photo_${index}_modified.png").sink().use { it.write(newBytes) }
+                SystemFileSystem
+                    .sink(Path("build/photo_${index}_modified.png"))
+                    .buffered()
+                    .use { it.write(newBytes) }
 
                 fail("Bytes for test image #$index are different.")
             }


### PR DESCRIPTION
Crashes on iOS and macOS may occur if exceptions other than ImageReadException and ImageWriteException (both declared using the Throws-Annotation) are raised. These fixes guarantee that no other type of Exception can occur, as all other exceptions are now encapsulated within either an ImageReadException or an ImageWriteException.

Also some minor updated and API migrations happened.