### PR TITLE
Fixes for JS target

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,7 +10,7 @@ Logic for reading ISOBMFF containers was derived from 'metadata-extractor'
 developed by Drew Noakes (https://github.com/drewnoakes/metadata-extractor).
 Copyright 2002-2023 Drew Noakes and contributors
 
-This product includes images from Unplash provided under
+This product includes images from Unsplash provided under
 the Unsplash license (https://unsplash.com/license).
 These files are used as test data.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ of Ashampoo Photos, which, in turn, is driven by user community feedback.
 ## Installation
 
 ```
-implementation("com.ashampoo:kim:0.16")
+implementation("com.ashampoo:kim:0.16.1")
+```
+
+For the targets `wasmJs` & `js` you also need to specify this:
+
+```
+implementation(npm("pako", "2.1.0"))
 ```
 
 ## Sample usages

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ val ktorVersion: String = "2.3.8"
 val xmpCoreVersion: String = "1.2.0"
 val dateTimeVersion: String = "0.5.0"
 val testRessourcesVersion: String = "0.4.0"
-val ioCoreVersion: String = "0.3.1"
+val ioCoreVersion: String = "0.3.2"
 
 description = productName
 group = "com.ashampoo"

--- a/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngImageParser.kt
+++ b/src/commonMain/kotlin/com/ashampoo/kim/format/png/PngImageParser.kt
@@ -39,7 +39,8 @@ import com.ashampoo.kim.model.ImageFormat
 
 object PngImageParser : ImageParser {
 
-    private val controlCharRegex = Regex("[\\p{Cntrl}]")
+    /* Note that [\\p{Cntrl}] does not work for Kotlin/JS. */
+    private val controlCharRegex = Regex("[\\x00-\\x1F\\x7F-\\x9F]")
 
     private val metadataChunkTypes = listOf(
         PngChunkType.IHDR,


### PR DESCRIPTION
- Use JS compatible regex in png parser
- Updated to kotlinx-io v0.3.2 for bugfixes