### PR TITLE
Added method to help usage on Android

### DIFF
--- a/src/androidMain/kotlin/com/ashampoo/kim/output/AndroidOutputStreamByteWriter.kt
+++ b/src/androidMain/kotlin/com/ashampoo/kim/output/AndroidOutputStreamByteWriter.kt
@@ -1,0 +1,24 @@
+package com.ashampoo.kim.output
+
+import java.io.OutputStream
+
+public open class AndroidOutputStreamByteWriter(
+    private val outputStream: OutputStream
+) : ByteWriter {
+
+    override fun write(byte: Int) {
+        outputStream.write(byte)
+    }
+
+    override fun write(byteArray: ByteArray) {
+        outputStream.write(byteArray)
+    }
+
+    override fun flush() {
+        outputStream.flush()
+    }
+
+    override fun close() {
+        outputStream.close()
+    }
+}


### PR DESCRIPTION
I've added my own methods to use Kim on Android.
I'm having issues adding tags directly, which I've worked around but I'm not proud of.

```
    fun addTag(
        byteReader: () -> ByteReader?,
        byteWriter: () -> ByteWriter?,
        block: (outputSet: TiffOutputSet) -> Unit
    ) {
        val metadata = byteReader()?.let {
            Kim.readMetadata(it)
        } ?: return

        val outputSet: TiffOutputSet = metadata.exif?.createOutputSet() ?: TiffOutputSet()

        block(outputSet)

        byteReader()?.let { byteReader ->
            // Currently bug with Android >29 with the direct byteWriter (Kim 0.22.1)
            val byteArrayByteWriter = ByteArrayByteWriter()
            JpegRewriter.updateExifMetadataLossless(
                byteReader = byteReader,
                byteWriter = byteArrayByteWriter,
                outputSet = outputSet
            )
            byteWriter()?.use { byteWriter ->
                byteWriter.write(byteArrayByteWriter.toByteArray())
            }
        }
    }
```

It's starting to get old and I'm sorry about that, so I don't really remember why your methods didn't work properly.